### PR TITLE
Temporarily disable CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Shopify/learn-libs-superteam
+# *       @Shopify/learn-libs-superteam


### PR DESCRIPTION
Just so that we're not constantly pinging everyone until we're done with the initial implementation