### PR TITLE
Add GDPR webhooks, plus APP_UNINSTALLED

### DIFF
--- a/web/app/jobs/app_uninstalled_job.rb
+++ b/web/app/jobs/app_uninstalled_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppUninstalledJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::Handler
 
@@ -17,9 +19,7 @@ class AppUninstalledJob < ActiveJob::Base
 
     logger.info("#{self.class} started for shop '#{shop_domain}'")
     users = User.where(shopify_domain: shop_domain)
-    users.each do |user|
-      user.destroy
-    end
+    users.each(&:destroy)
     shop.destroy
   end
 end

--- a/web/app/jobs/customers_data_request_job.rb
+++ b/web/app/jobs/customers_data_request_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CustomersDataRequestJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::Handler
 

--- a/web/app/jobs/customers_redact_job.rb
+++ b/web/app/jobs/customers_redact_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CustomersRedactJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::Handler
 

--- a/web/app/jobs/shop_redact_job.rb
+++ b/web/app/jobs/shop_redact_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ShopRedactJob < ActiveJob::Base
   extend ShopifyAPI::Webhooks::Handler
 

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -54,10 +54,9 @@ end
 
 def add_gdpr_webhooks
   gdpr_webhooks = [
-    # NOTE 1: To register the URLs for the three GDPR topics that follow, please set the appropriate
+    # NOTE: To register the URLs for the three GDPR topics that follow, please set the appropriate
     # webhook endpoint in the 'GDPR mandatory webhooks' section of 'App setup' in the Partners Dashboard.
-    #
-    # NOTE 2: The code that processes these webhooks is located in the `app/jobs` directory.
+    # The code that processes these webhooks is located in the `app/jobs` directory.
     #
     # 48 hours after a store owner uninstalls your app, Shopify invokes this SHOP_REDACT webhook.
     # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#shop-redact

--- a/web/test/jobs/app_uninstalled_job_test.rb
+++ b/web/test/jobs/app_uninstalled_job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class AppUninstalledJobTest < ActiveJob::TestCase

--- a/web/test/jobs/customers_data_request_job_test.rb
+++ b/web/test/jobs/customers_data_request_job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class CustomersDataRequestJobTest < ActiveJob::TestCase

--- a/web/test/jobs/customers_redact_job_test.rb
+++ b/web/test/jobs/customers_redact_job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class CustomersRedactJobTest < ActiveJob::TestCase

--- a/web/test/jobs/shop_redact_job_test.rb
+++ b/web/test/jobs/shop_redact_job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ShopRedactJobTest < ActiveJob::TestCase


### PR DESCRIPTION
### WHY are these changes introduced?

Adds webhook handers for GDPR topics
- `CUSTOMERS_DATA_REQUEST`
- `CUSTOMERS_REDACT`
- `SHOP_REDACT`

plus
- `APP_UNINSTALLED`

Closes https://github.com/Shopify/first-party-library-planning/issues/331

### WHAT is this pull request doing?

☝🏻 !