### PR TITLE
Fix app gem temporary github branch

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -77,6 +77,6 @@ group :test do
 end
 
 # TODO: Pull from the latest release once this change is published
-git "https://github.com/Shopify/shopify_app.git", branch: "set_redirection_headers" do
+git "https://github.com/Shopify/shopify_app.git", branch: "main" do
   gem "shopify_app", "~> 19.0"
 end


### PR DESCRIPTION
This is just fixing the branch to use main since the temporary branch was merged.