### PR TITLE
Allow requests from all ngrok regions in development

### DIFF
--- a/web/config/environments/development.rb
+++ b/web/config/environments/development.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
     config.hosts
   rescue
     []
-  end << /[-\w]+\.ngrok\.io/
+  end << /[-.\w]+\.ngrok\.io/
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
### WHY are these changes introduced?

Requests tunnelled through ngrok regions other than the `us` region will have the region prefix in the subdomain in an additional segment. By default the `ngrok` client [chooses the region closest to you](https://ngrok.com/docs/ngrok-agent/config#config-region). This means that developers in Europe can have a tunnel URL in the form of  `74f9-82-131-61-229.eu.ngrok.io`, in Asia `74f9-82-131-61-229.jp.ngrok.io` etc.

Right now requests tunnelled through a different ngrok region than `us` are not matched by the permitted hosts regexp.
When trying to install the app in the development store (when situated in Europe, or having a default region other than `us` set in the local ngrok config), this error appears:

<img width="814" alt="image" src="https://user-images.githubusercontent.com/1100176/174084378-bdefe5a1-5058-4f89-9be6-c2a116d2ab68.png">

### WHAT is this pull request doing?

This change allows all potential ngrok subdomains to be matched regardless of which region a developer is in, thus allowing developers from around the world to use ngrok without setting the `us` region as the default region on their local development machines.

Adding the `.` to the allowed characters allows to match the additional domain segment: https://rubular.com/r/dm9KAyrfyuNh1q

## Checklist

- [-] I have added/updated tests for this change (not applicable)
