### PR TITLE
Add support for billing

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -77,6 +77,6 @@ group :test do
 end
 
 # TODO: Pull from the latest release once this change is published
-git "https://github.com/Shopify/shopify_app.git", branch: "main" do
+git "https://github.com/Shopify/shopify_app.git", branch: "add_billing_support" do
   gem "shopify_app", "~> 19.0"
 end

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -22,6 +22,19 @@ ShopifyApp.configure do |config|
   config.login_url = "/api/auth"
   config.login_callback_url = "/api/auth/callback"
 
+  # You may want to charge merchants for using your app. Setting the billing configuration will cause the Authenticated
+  # controller concern to check that the session is for a merchant that has an active one-time payment or subscription.
+  # If no payment is found, it starts off the process and sends the merchant to a confirmation URL so that they can
+  # approve the purchase.
+  #
+  # Learn more about billing in our documentation: https://shopify.dev/apps/billing
+  # config.billing = ShopifyApp::BillingConfiguration.new(
+  #   charge_name: "My app billing charge",
+  #   amount: 5,
+  #   interval: ShopifyApp::BillingConfiguration::INTERVAL_ANNUAL,
+  #   currency_code: "USD", # Only supports USD for now
+  # )
+
   config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
   config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
 


### PR DESCRIPTION
This PR changes the template to start using the upcoming support for billing in `shopify_app`