### PR TITLE
Move production index.html into dist folder

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -31,7 +31,7 @@
 
 /public/assets
 /public/api/assets
-/public/index.html
+/public/dist/index.html
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/web/app/controllers/home_controller.rb
+++ b/web/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
   include ShopifyApp::ShopAccessScopesVerification
 
   DEV_INDEX_PATH = Rails.root.join("frontend")
-  PROD_INDEX_PATH = Rails.root.join("frontend/dist")
+  PROD_INDEX_PATH = Rails.public_path.join("dist")
 
   def index
     contents = File.read(File.join(Rails.env.production? ? PROD_INDEX_PATH : DEV_INDEX_PATH, "index.html"))

--- a/web/lib/tasks/build.rake
+++ b/web/lib/tasks/build.rake
@@ -6,7 +6,7 @@ namespace :build do
 
   desc "Build symlinks for FE assets"
   task build_frontend_links: :environment do
-    index_path = File.join(__dir__, "../../public/index.html")
+    index_path = File.join(__dir__, "../../public/dist/index.html")
     assets_path = File.join(__dir__, "../../public/assets")
 
     File.symlink(File.join(__dir__, "../../frontend/dist/index.html"), index_path) unless File.symlink?(index_path)


### PR DESCRIPTION
### WHY are these changes introduced?

If a developer was running `dev` after a `build` call, the app would try to load `public/index.html` instead of reaching the root endpoint, which broke everything.

### WHAT is this pull request doing?

Moving the symlink one level down so we're not loading it directly - that file is loaded by the root endpoint anyway, so it wouldn't break any requests to `/`.