### PR TITLE
Change 'composer build' to 'rake build:all'

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ If you're manually building (for instance when deploying the `web` folder to pro
 cd web/frontend
 SHOPIFY_API_KEY=REPLACE_ME yarn build
 cd ..
-composer build
+rake build:all
 ```
 
 ## Hosting

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -77,6 +77,6 @@ group :test do
 end
 
 # TODO: Pull from the latest release once this change is published
-git "https://github.com/Shopify/shopify_app.git", branch: "add_billing_support" do
+git "https://github.com/Shopify/shopify_app.git" do
   gem "shopify_app", "~> 19.0"
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Copy/paste error from PHP README

### WHAT is this pull request doing?

Change `composer build` to `rake build:all`
