### PR TITLE
Allow new Ngrok URLs

### DIFF
--- a/web/config/environments/development.rb
+++ b/web/config/environments/development.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
     config.hosts
   rescue
     []
-  end << /[-\w]+\.ngrok\.io/
+  end << /[-\w.]+\.ngrok\.io/
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
### WHY are these changes introduced?

Ngrok v3 now includes the region in the URLs, like `https://fd15-87-220-76-32.eu.ngrok.io` instead of just `https://fd15-87-220-76-32.ngrok.io`.

### WHAT is this pull request doing?

Fixes the ngrok regex to allow the new URLs in the development config.

## Checklist

- [ ] I have added/updated tests for this change
- [ ] I have incremented the version in the top-level `package.json` file **AND** in the `web/version.txt` file
- [ ] I have added an entry to the `CHANGELOG.md` file
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
