### PR TITLE
Fix npm init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ yarn create @shopify/app --template ruby
 Using npx:
 
 ```shell
-npm init @shopify/app --template ruby
+npm init @shopify/app@latest --template ruby
 ```
 
 Using pnpm:


### PR DESCRIPTION
### WHY are these changes introduced?

`npm init` caches heavily, hence need to force it to get the latest version

### WHAT is this pull request doing?

Change the `npm init @shopify/app --template ruby` to `npm init @shopify/app@latest --template ruby`