### PR TITLE
Update API repo links (post Editions 2022 tidy-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This template combines a number of third party open source tools:
 
 These third party tools are complemented by Shopify specific tools to ease app development:
 
-- [Shopify API library](https://github.com/Shopify/shopify_api) adds OAuth to the Rails backend. This lets users install the app and grant scope permissions.
+- [Shopify API library](https://github.com/Shopify/shopify-api-ruby) adds OAuth to the Rails backend. This lets users install the app and grant scope permissions.
 - [App Bridge React](https://shopify.dev/tools/app-bridge/react-components) adds authentication to API requests in the frontend and renders components outside of the App’s iFrame.
 - [Polaris React](https://polaris.shopify.com/) is a powerful design system and component library that helps developers build high quality, consistent experiences for Shopify merchants.
 - [Custom hooks](https://github.com/Shopify/shopify-frontend-template-react/tree/main/hooks) make authenticated requests to the GraphQL Admin API.
@@ -263,4 +263,4 @@ pnpm dev --tunnel-url https://tunnel-url:3000
 - [Introduction to Shopify apps](https://shopify.dev/apps/getting-started)
 - [App authentication](https://shopify.dev/apps/auth)
 - [Shopify CLI](https://shopify.dev/apps/tools/cli)
-- [Shopify API Library documentation](https://github.com/Shopify/shopify_api/tree/main/docs)
+- [Shopify API Library documentation](https://github.com/Shopify/shopify-api-ruby/tree/main/docs)


### PR DESCRIPTION

### Why is this PR needed

As part of the Shopify API and app template strategy, the public repos were renamed to provide a more consistent naming convention.

### What this PR is doing

Where applicable, this PR renames the following repos to match the new naming convention.
- `Shopify/shopify_api` -> `Shopify/shopify-api-ruby`
- `Shopify/shopify-node-api` -> `Shopify/shopify-api-node`
- `Shopify/shopify-php-api` -> `Shopify/shopify-api-php`
- `Shopify/shopify-app-node` -> `Shopify/shopify-app-template-node`
- `Shopify/shopify-app-php` -> `Shopify/shopify-app-template-php`

