### PR TITLE
Fix "Installing the template" examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ This template runs on Shopify CLI 3.0, which is a node package that can be inclu
 Using yarn:
 
 ```shell
-yarn create @shopify/app --template ruby
+yarn create @shopify/app --template=ruby
 ```
 
 Using npx:
 
 ```shell
-npm init @shopify/app@latest --template ruby
+npm init @shopify/app@latest --template=ruby
 ```
 
 Using pnpm:
 
 ```shell
-pnpm create @shopify/app@latest --template ruby
+pnpm create @shopify/app@latest --template=ruby
 ```
 
 This will clone the template and install the CLI in that project.


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

I landed on this repo from https://shopify.dev/apps/tools#app-templates and tried to create a ruby app.

It failed with the following error (see below). Adding an `=` to the `--template` flag allowed the command to run sucessfully.

```
➜  vault-pages git:(app-creation-using-spin) npm init @shopify/app@latest --template ruby
Need to install the following packages:
  @shopify/create-app@latest
Ok to proceed? (y) y

━━━━━━ Error ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    Unexpected argument: ruby
    See more help with --help

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

npm ERR! code 1
npm ERR! path /Users/petar/src/github.com/Shopify/vault-pages
npm ERR! command failed
npm ERR! command sh -c create-app "ruby"

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/petar/.npm/_logs/2022-07-28T18_51_39_967Z-debug-0.log
```

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds an equal sign to the `--template` flag for the "Installing the template" examples

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [X] I have added/updated tests for this change
- [X] I have made changes to the `README.md` file and other related documentation, if applicable
