### PR TITLE
Add processing for OAuth flicker reduction

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -75,4 +75,4 @@ group :test do
   gem "webdrivers"
 end
 
-gem "shopify_app", "~> 19.0"
+gem "shopify_app", "~> 20.1"

--- a/web/app/controllers/home_controller.rb
+++ b/web/app/controllers/home_controller.rb
@@ -9,8 +9,12 @@ class HomeController < ApplicationController
   PROD_INDEX_PATH = Rails.public_path.join("dist")
 
   def index
-    contents = File.read(File.join(Rails.env.production? ? PROD_INDEX_PATH : DEV_INDEX_PATH, "index.html"))
+    if ShopifyAPI::Context.embedded? && !params[:embedded].present? || params[:embedded] != "1"
+      redirect_to(ShopifyAPI::Auth.embedded_app_url(params[:host]), allow_other_host: true)
+    else
+      contents = File.read(File.join(Rails.env.production? ? PROD_INDEX_PATH : DEV_INDEX_PATH, "index.html"))
 
-    render(plain: contents, content_type: "text/html", layout: false)
+      render(plain: contents, content_type: "text/html", layout: false)
+    end
   end
 end

--- a/web/app/services/application_service.rb
+++ b/web/app/services/application_service.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class ApplicationService
-  def self.call(*args, **kwargs, &block)
-    new(*args, **kwargs, &block).call
+  class << self
+    def call(*args, **kwargs, &block)
+      new(*args, **kwargs, &block).call
+    end
   end
 end

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -20,6 +20,7 @@ ShopifyApp.configure do |config|
   config.root_url = "/api"
   config.login_url = "/api/auth"
   config.login_callback_url = "/api/auth/callback"
+  config.embedded_redirect_url = "/ExitIframe"
 
   # You may want to charge merchants for using your app. Setting the billing configuration will cause the Authenticated
   # controller concern to check that the session is for a merchant that has an active one-time payment or subscription.


### PR DESCRIPTION
### WHY are these changes introduced?

With the addition of the `embedded` param coming from Shopify, we can optimize the processing of OAuth to avoid screen flickering (switching to full screen then back again to iFrame, etc.)

Fixes https://github.com/Shopify/first-party-library-planning/issues/393

### WHAT is this pull request doing?

Added `embedded_app_url` to `config` to point to `/ExitIframe`, page in FE.  Also added checking of `embedded` parameter from Shopify to determine if top-level or in an iframe.  Will redirect (via App Bridge) to load app in iFrame if top-level.

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

