### PR TITLE
Rename scaffold to generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "shopify app build",
     "dev": "shopify app dev",
     "push": "shopify app push",
-    "scaffold": "shopify app scaffold",
+    "generate": "shopify app generate",
     "deploy": "shopify app deploy",
     "info": "shopify app info"
   },


### PR DESCRIPTION
Related: https://github.com/Shopify/cli/pull/376

### WHY are these changes introduced?
We are renaming `scaffold` to `generate` so I'm updating the template to reflect the change.


### Note
This PR should be merged after the next version of the CLI containing [these changes](https://github.com/Shopify/cli/pull/376) have been released.