### PR TITLE
Added support for custom store domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ To fix the problem you should modify the file `web/config/initializers/shopify_a
 ```ruby
   config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
   config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
-  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence unless ENV.fetch("SHOP_CUSTOM_DOMAIN", "").empty?
+  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence
 ```
 
 In case the CLI version used does not support the environment varibale `SHOP_CUSTOM_DOMAIN` you should add you complete spin domain. If the url of one of your stores is https://spin-store.shopify.constellation-t90f.my-spin-instance.eu.spin.dev/ the content of the context should be:

--- a/README.md
+++ b/README.md
@@ -252,6 +252,23 @@ npm run dev --tunnel-url https://tunnel-url:3000
 pnpm dev --tunnel-url https://tunnel-url:3000
 ```
 
+### I want to run the CLI inside a spin instance but my store domain is not valid
+When you run a `dev` command and open the app url in the browser and you are prompted to `Enter your shop domain to log in or install this app.`. This means that the shop domain used is not valid. Despite entering the correct shop domain in the form you will always received an `Invalid shop domain` error message.
+
+To fix the problem you should modify the file `web/config/initializers/shopify_app.rb` to set the proper value to the config variable `config.myshopify_domain` like this:
+```ruby
+  config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
+  config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
+  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence unless ENV.fetch("SHOP_CUSTOM_DOMAIN", "").empty?
+```
+
+In case the CLI version used does not support the environment varibale `SHOP_CUSTOM_DOMAIN` you should add you complete spin domain. If the url of one of your stores is https://spin-store.shopify.constellation-t90f.my-spin-instance.eu.spin.dev/ the content of the context should be:
+```ruby
+  config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
+  config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
+  config.myshopify_domain = "shopify.constellation-t90f.my-spin-instance.eu.spin.dev"
+```
+
 ## Developer resources
 
 - [Introduction to Shopify apps](https://shopify.dev/apps/getting-started)

--- a/README.md
+++ b/README.md
@@ -252,23 +252,6 @@ npm run dev --tunnel-url https://tunnel-url:3000
 pnpm dev --tunnel-url https://tunnel-url:3000
 ```
 
-### I want to run the CLI inside a spin instance but my store domain is not valid
-When you run a `dev` command and open the app url in the browser and you are prompted to `Enter your shop domain to log in or install this app.`. This means that the shop domain used is not valid. Despite entering the correct shop domain in the form you will always received an `Invalid shop domain` error message.
-
-To fix the problem you should modify the file `web/config/initializers/shopify_app.rb` to set the proper value to the config variable `config.myshopify_domain` like this:
-```ruby
-  config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
-  config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
-  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence
-```
-
-In case the CLI version used does not support the environment varibale `SHOP_CUSTOM_DOMAIN` you should add you complete spin domain. If the url of one of your stores is https://spin-store.shopify.constellation-t90f.my-spin-instance.eu.spin.dev/ the content of the context should be:
-```ruby
-  config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
-  config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
-  config.myshopify_domain = "shopify.constellation-t90f.my-spin-instance.eu.spin.dev"
-```
-
 ## Developer resources
 
 - [Introduction to Shopify apps](https://shopify.dev/apps/getting-started)

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -37,7 +37,7 @@ ShopifyApp.configure do |config|
 
   config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
   config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
-  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence unless ENV.fetch("SHOP_CUSTOM_DOMAIN", "").empty?
+  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence
 
   if defined? Rails::Server
     raise("Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements") unless config.api_key
@@ -58,7 +58,7 @@ Rails.application.config.after_initialize do
       session_storage: ShopifyApp::SessionRepository,
       logger: Rails.logger,
       private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
-      user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
+      user_agent_prefix:can  "ShopifyApp/#{ShopifyApp::VERSION}",
     )
 
     add_gdpr_webhooks

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -37,6 +37,7 @@ ShopifyApp.configure do |config|
 
   config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
   config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
+  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence unless ENV.fetch("SHOP_CUSTOM_DOMAIN", "").empty?
 
   if defined? Rails::Server
     raise("Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements") unless config.api_key

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -4,23 +4,23 @@ ShopifyApp.configure do |config|
   config.webhooks = [
     # After a store owner uninstalls your app, Shopify invokes the APP_UNINSTALLED webhook
     # to let your app know.
-    { topic: 'app/uninstalled', address: 'api/webhooks/app_uninstalled' }
+    { topic: "app/uninstalled", address: "api/webhooks/app_uninstalled" },
   ]
-  config.application_name = 'My Shopify App'
-  config.old_secret = ''
-  config.scope = ENV.fetch('SCOPES', 'write_products') # See shopify.app.toml for scopes
+  config.application_name = "My Shopify App"
+  config.old_secret = ""
+  config.scope = ENV.fetch("SCOPES", "write_products") # See shopify.app.toml for scopes
   # Consult this page for more scope options: https://shopify.dev/api/usage/access-scopes
   config.embedded_app = true
   config.after_authenticate_job = false
   config.api_version = ShopifyAPI::AdminVersions::LATEST_SUPPORTED_ADMIN_VERSION
-  config.shop_session_repository = 'Shop'
+  config.shop_session_repository = "Shop"
 
   config.reauth_on_access_scope_changes = true
 
-  config.root_url = '/api'
-  config.login_url = '/api/auth'
-  config.login_callback_url = '/api/auth/callback'
-  config.embedded_redirect_url = '/ExitIframe'
+  config.root_url = "/api"
+  config.login_url = "/api/auth"
+  config.login_callback_url = "/api/auth/callback"
+  config.embedded_redirect_url = "/ExitIframe"
 
   # You may want to charge merchants for using your app. Setting the billing configuration will cause the Authenticated
   # controller concern to check that the session is for a merchant that has an active one-time payment or subscription.
@@ -35,14 +35,13 @@ ShopifyApp.configure do |config|
   #   currency_code: "USD", # Only supports USD for now
   # )
 
-  config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence
-  config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence
-  config.myshopify_domain = ENV.fetch('SHOP_CUSTOM_DOMAIN', '').presence unless ENV.fetch('SHOP_CUSTOM_DOMAIN',
-                                                                                          '').empty?
+  config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
+  config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
+  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence unless ENV.fetch("SHOP_CUSTOM_DOMAIN", "").empty?
 
   if defined? Rails::Server
-    raise('Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements') unless config.api_key
-    raise('Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#requirements') unless config.secret
+    raise("Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements") unless config.api_key
+    raise("Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#requirements") unless config.secret
   end
 end
 
@@ -52,14 +51,14 @@ Rails.application.config.after_initialize do
       api_key: ShopifyApp.configuration.api_key,
       api_secret_key: ShopifyApp.configuration.secret,
       api_version: ShopifyApp.configuration.api_version,
-      host_name: URI(ENV.fetch('HOST', '')).host || '',
+      host_name: URI(ENV.fetch("HOST", "")).host || "",
       scope: ShopifyApp.configuration.scope,
-      is_private: !ENV.fetch('SHOPIFY_APP_PRIVATE_SHOP', '').empty?,
+      is_private: !ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", "").empty?,
       is_embedded: ShopifyApp.configuration.embedded_app,
       session_storage: ShopifyApp::SessionRepository,
       logger: Rails.logger,
-      private_shop: ENV.fetch('SHOPIFY_APP_PRIVATE_SHOP', nil),
-      user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}"
+      private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
+      user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
     )
 
     add_gdpr_webhooks
@@ -75,22 +74,22 @@ def add_gdpr_webhooks
     #
     # 48 hours after a store owner uninstalls your app, Shopify invokes this SHOP_REDACT webhook.
     # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#shop-redact
-    { topic: 'shop/redact', address: 'api/webhooks/shop_redact' },
+    { topic: "shop/redact", address: "api/webhooks/shop_redact" },
 
     # Store owners can request that data is deleted on behalf of a customer. When this happens,
     # Shopify invokes this CUSTOMERS_REDACT webhook to let your app know.
     # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-redact
-    { topic: 'customers/redact', address: 'api/webhooks/customers_redact' },
+    { topic: "customers/redact", address: "api/webhooks/customers_redact" },
 
     # Customers can request their data from a store owner. When this happens, Shopify invokes
     # this CUSTOMERS_DATA_REQUEST webhook to let your app know.
     # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
-    { topic: 'customers/data_request', address: 'api/webhooks/customers_data_request' }
+    { topic: "customers/data_request", address: "api/webhooks/customers_data_request" },
   ]
 
   ShopifyApp.configuration.webhooks = if ShopifyApp.configuration.has_webhooks?
-                                        ShopifyApp.configuration.webhooks.concat(gdpr_webhooks)
-                                      else
-                                        gdpr_webhooks
-                                      end
+    ShopifyApp.configuration.webhooks.concat(gdpr_webhooks)
+  else
+    gdpr_webhooks
+  end
 end

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -4,23 +4,23 @@ ShopifyApp.configure do |config|
   config.webhooks = [
     # After a store owner uninstalls your app, Shopify invokes the APP_UNINSTALLED webhook
     # to let your app know.
-    { topic: "app/uninstalled", address: "api/webhooks/app_uninstalled" },
+    { topic: 'app/uninstalled', address: 'api/webhooks/app_uninstalled' }
   ]
-  config.application_name = "My Shopify App"
-  config.old_secret = ""
-  config.scope = ENV.fetch("SCOPES", "write_products") # See shopify.app.toml for scopes
+  config.application_name = 'My Shopify App'
+  config.old_secret = ''
+  config.scope = ENV.fetch('SCOPES', 'write_products') # See shopify.app.toml for scopes
   # Consult this page for more scope options: https://shopify.dev/api/usage/access-scopes
   config.embedded_app = true
   config.after_authenticate_job = false
   config.api_version = ShopifyAPI::AdminVersions::LATEST_SUPPORTED_ADMIN_VERSION
-  config.shop_session_repository = "Shop"
+  config.shop_session_repository = 'Shop'
 
   config.reauth_on_access_scope_changes = true
 
-  config.root_url = "/api"
-  config.login_url = "/api/auth"
-  config.login_callback_url = "/api/auth/callback"
-  config.embedded_redirect_url = "/ExitIframe"
+  config.root_url = '/api'
+  config.login_url = '/api/auth'
+  config.login_callback_url = '/api/auth/callback'
+  config.embedded_redirect_url = '/ExitIframe'
 
   # You may want to charge merchants for using your app. Setting the billing configuration will cause the Authenticated
   # controller concern to check that the session is for a merchant that has an active one-time payment or subscription.
@@ -35,13 +35,14 @@ ShopifyApp.configure do |config|
   #   currency_code: "USD", # Only supports USD for now
   # )
 
-  config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
-  config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
-  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence unless ENV.fetch("SHOP_CUSTOM_DOMAIN", "").empty?
+  config.api_key = ENV.fetch('SHOPIFY_API_KEY', '').presence
+  config.secret = ENV.fetch('SHOPIFY_API_SECRET', '').presence
+  config.myshopify_domain = ENV.fetch('SHOP_CUSTOM_DOMAIN', '').presence unless ENV.fetch('SHOP_CUSTOM_DOMAIN',
+                                                                                          '').empty?
 
   if defined? Rails::Server
-    raise("Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements") unless config.api_key
-    raise("Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#requirements") unless config.secret
+    raise('Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements') unless config.api_key
+    raise('Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#requirements') unless config.secret
   end
 end
 
@@ -51,14 +52,14 @@ Rails.application.config.after_initialize do
       api_key: ShopifyApp.configuration.api_key,
       api_secret_key: ShopifyApp.configuration.secret,
       api_version: ShopifyApp.configuration.api_version,
-      host_name: URI(ENV.fetch("HOST", "")).host || "",
+      host_name: URI(ENV.fetch('HOST', '')).host || '',
       scope: ShopifyApp.configuration.scope,
-      is_private: !ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", "").empty?,
+      is_private: !ENV.fetch('SHOPIFY_APP_PRIVATE_SHOP', '').empty?,
       is_embedded: ShopifyApp.configuration.embedded_app,
       session_storage: ShopifyApp::SessionRepository,
       logger: Rails.logger,
-      private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
-      user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
+      private_shop: ENV.fetch('SHOPIFY_APP_PRIVATE_SHOP', nil),
+      user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}"
     )
 
     add_gdpr_webhooks
@@ -74,22 +75,22 @@ def add_gdpr_webhooks
     #
     # 48 hours after a store owner uninstalls your app, Shopify invokes this SHOP_REDACT webhook.
     # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#shop-redact
-    { topic: "shop/redact", address: "api/webhooks/shop_redact" },
+    { topic: 'shop/redact', address: 'api/webhooks/shop_redact' },
 
     # Store owners can request that data is deleted on behalf of a customer. When this happens,
     # Shopify invokes this CUSTOMERS_REDACT webhook to let your app know.
     # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-redact
-    { topic: "customers/redact", address: "api/webhooks/customers_redact" },
+    { topic: 'customers/redact', address: 'api/webhooks/customers_redact' },
 
     # Customers can request their data from a store owner. When this happens, Shopify invokes
     # this CUSTOMERS_DATA_REQUEST webhook to let your app know.
     # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
-    { topic: "customers/data_request", address: "api/webhooks/customers_data_request" },
+    { topic: 'customers/data_request', address: 'api/webhooks/customers_data_request' }
   ]
 
   ShopifyApp.configuration.webhooks = if ShopifyApp.configuration.has_webhooks?
-    ShopifyApp.configuration.webhooks.concat(gdpr_webhooks)
-  else
-    gdpr_webhooks
-  end
+                                        ShopifyApp.configuration.webhooks.concat(gdpr_webhooks)
+                                      else
+                                        gdpr_webhooks
+                                      end
 end

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -58,7 +58,7 @@ Rails.application.config.after_initialize do
       session_storage: ShopifyApp::SessionRepository,
       logger: Rails.logger,
       private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
-      user_agent_prefix:can  "ShopifyApp/#{ShopifyApp::VERSION}",
+      user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
     )
 
     add_gdpr_webhooks


### PR DESCRIPTION
### WHY are these changes introduced?
Some teams want to run CLI3 inside a spin instance. Right now this is not possible because the spin shop url domains are not supported by default. Although the users could configure their specific domain manually there will be less friction if the CLI could set that custom domain in an automatic way when the dev command is used.

For a more complete context of the problem to solve there is a [doc](https://docs.google.com/document/d/1V1lMGR5uqi2Lsy8Y1e2zj_-8cGUFjUbVOZ-2z4CuQA4/edit#)

### WHAT is this pull request doing?
Receive a custom store domain using environment variables and configure `config.myshopify_domain`