### PR TITLE
Support custom domains hosts

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -75,4 +75,4 @@ group :test do
   gem "webdrivers"
 end
 
-gem "shopify_app", "~> 21.0.0"
+gem "shopify_app", "~> 21.2.0"

--- a/web/config/environments/development.rb
+++ b/web/config/environments/development.rb
@@ -8,6 +8,11 @@ Rails.application.configure do
   rescue
     []
   end << /[-\w.]+\.ngrok\.io/
+
+  if ENV.fetch("SHOP_CUSTOM_DOMAIN", "").present?
+    custom_host = Regexp.new '[\\w\.]+' +  ENV.fetch("SHOP_CUSTOM_DOMAIN").sub("shopify","").gsub("\.","\\.")
+    config.hosts << custom_host
+  end
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/web/config/environments/development.rb
+++ b/web/config/environments/development.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   end << /[-\w.]+\.ngrok\.io/
 
   if ENV.fetch("SHOP_CUSTOM_DOMAIN", "").present?
-    custom_host = Regexp.new '[\\w\.]+' +  ENV.fetch("SHOP_CUSTOM_DOMAIN").sub("shopify","").gsub("\.","\\.")
+    custom_host = Regexp.new('[\\w\.]+' + ENV.fetch("SHOP_CUSTOM_DOMAIN").sub("shopify", "").gsub("\.", "\\."))
     config.hosts << custom_host
   end
   # Settings specified here will take precedence over those in config/application.rb.

--- a/web/config/environments/development.rb
+++ b/web/config/environments/development.rb
@@ -9,10 +9,7 @@ Rails.application.configure do
     []
   end << /[-\w.]+\.ngrok\.io/
 
-  if ENV.fetch("SHOP_CUSTOM_DOMAIN", "").present?
-    custom_host = Regexp.new('[\\w\.]+' + ENV.fetch("SHOP_CUSTOM_DOMAIN").sub("shopify", "").gsub("\.", "\\."))
-    config.hosts << custom_host
-  end
+  config.hosts << URI(ENV.fetch("HOST", "")).host if ENV.fetch("HOST", "").present?
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Some teams want to run CLI3 inside a spin instance without using `ngrok` nor any other tunnelling solution. To achieve that an `nginx` configuration is going to be added to the partners constellation [here](https://github.com/Shopify/partners/pull/42756). Once merged, the requests to access the CLI should point to `cli.{SPIN_FQDN}`.
Right now, the template is not supporting any custom host except for `ngrok`
An external way to set a custom value for the setting `hosts` must be added

### WHAT is this pull request doing?
- The env variable `SHOP_CUSTOM_DOMAIN` added to support custom store domains is reused [here](https://github.com/Shopify/shopify-app-template-ruby/pull/44) for setting the `hosts`
- The value of the  `SHOP_CUSTOM_DOMAIN` env variable always contains the prefix `shopify` prepending the real domain.
- The prefix must be removed before setting the `hosts` value.
- The decision of reusing the variable is for not adding a new one specific for the Ruby template

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
