### PR TITLE
Set SHOP_CUSTOM_DOMAIN only if present

### DIFF
--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -37,7 +37,7 @@ ShopifyApp.configure do |config|
 
   config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
   config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
-  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence
+  config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence if ENV.fetch("SHOP_CUSTOM_DOMAIN", "").present?
 
   if defined? Rails::Server
     raise("Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements") unless config.api_key


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Fixes a bug when creating a new app and it is used outside spin.  This [change](https://github.com/Shopify/shopify-app-template-ruby/pull/44) allows setting the variable `config.myshopify_domain` from a new ENV `SHOP_CUSTOM_DOMAIN`. In case the ENV is not set, the `config.myshopify_domain` gets a `nil` value so when the app is run, this error appears
![image](https://user-images.githubusercontent.com/105213827/197199161-664c473a-d1cb-4494-a359-34ae3e38a163.png)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- The value of  `config.myshopify_domain` is only overwritten in case there is a value in the ENV `SHOP_CUSTOM_DOMAIN`

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
