### PR TITLE
Remove Deprecated Names

### DIFF
--- a/web/app/controllers/authenticated_controller.rb
+++ b/web/app/controllers/authenticated_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class AuthenticatedController < ApplicationController
-  include ShopifyApp::Authenticated
+  include ShopifyApp::EnsureHasSession
 end

--- a/web/app/controllers/home_controller.rb
+++ b/web/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@
 
 class HomeController < ApplicationController
   include ShopifyApp::EmbeddedApp
-  include ShopifyApp::RequireKnownShop
+  include ShopifyApp::EnsureInstalled
   include ShopifyApp::ShopAccessScopesVerification
 
   DEV_INDEX_PATH = Rails.root.join("frontend")

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -55,8 +55,8 @@ Rails.application.config.after_initialize do
       scope: ShopifyApp.configuration.scope,
       is_private: !ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", "").empty?,
       is_embedded: ShopifyApp.configuration.embedded_app,
-      session_storage: ShopifyApp::SessionRepository,
       logger: Rails.logger,
+      log_level: :info,
       private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
       user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
     )


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

`shopify_app` is seeing some new deprecations. Then template shouldn't be seeing any deprecation warnings, on new apps.

### WHAT is this pull request doing?

Changed any `ShopifyApp::Authenticated` calls to `ShopifyApp::EnsureHasSession`
Changed any `ShopifyApp::RequireKnownShop` to `ShopifyApp::EnsureInstalled`

Add `log_level` to context
Removed `session_storage` from context

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
