### PR TITLE
Update shopify_app to 21.4.0

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -75,4 +75,4 @@ group :test do
   gem "webdrivers"
 end
 
-gem "shopify_app", "~> 21.3.0"
+gem "shopify_app", "~> 21.4"

--- a/web/config/environments/production.rb
+++ b/web/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_09_125631) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_22_200143) do
   create_table "shops", force: :cascade do |t|
     t.string "shopify_domain", null: false
     t.string "shopify_token", null: false
@@ -18,6 +18,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_09_125631) do
     t.datetime "updated_at", null: false
     t.string "access_scopes"
     t.index ["shopify_domain"], name: "index_shops_on_shopify_domain", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.bigint "shopify_user_id", null: false
+    t.string "shopify_domain", null: false
+    t.string "shopify_token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "access_scopes"
+    t.index ["shopify_user_id"], name: "index_users_on_shopify_user_id", unique: true
   end
 
 end


### PR DESCRIPTION
This PR simply updates the dependency for the `shopify_app` gem. The schema file update was automatic when I rebuilt the app to test, so I think we may have missed updating it before.