### PR TITLE
Fix deployment issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.1-alpine
 ARG SHOPIFY_API_KEY
 ENV SHOPIFY_API_KEY=$SHOPIFY_API_KEY
 
-RUN apk update && apk add nodejs npm git build-base sqlite-dev gcompat bash
+RUN apk update && apk add nodejs npm git build-base sqlite-dev gcompat bash openssl-dev
 WORKDIR /app
 
 COPY web .

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.2"
+ruby "~> 3.1"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.3"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-dev/issues/29573

There was a little bit of drift since the template was updated, and a new ruby version broke building the Docker container because a new ruby version was released.

### WHAT is this pull request doing?

Making the ruby version in the Gemfile a little more flexible, and ensuring the `openssl` package gets installed in the Docker container, so that the build process works normally again.
