### PR TITLE
Update shopify.dev links to include /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Shopify App Template - Ruby
 
-This is a template for building a [Shopify app](https://shopify.dev/apps/getting-started) using Ruby on Rails and React. It contains the basics for building a Shopify app.
+This is a template for building a [Shopify app](https://shopify.dev/docs/apps/getting-started) using Ruby on Rails and React. It contains the basics for building a Shopify app.
 
 Rather than cloning this repo, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
 
 ## Benefits
 
-Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app using this template.
+Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/docs/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app using this template.
 
 The Ruby app template comes with the following out-of-the-box functionality:
 
@@ -30,7 +30,7 @@ This template combines a number of third party open source tools:
 These third party tools are complemented by Shopify specific tools to ease app development:
 
 - [Shopify API library](https://github.com/Shopify/shopify-api-ruby) adds OAuth to the Rails backend. This lets users install the app and grant scope permissions.
-- [App Bridge](https://shopify.dev/apps/tools/app-bridge) and [App Bridge React](https://shopify.dev/apps/tools/app-bridge/getting-started/using-react) add authentication to API requests in the frontend and renders components outside of the App’s iFrame.
+- [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge) and [App Bridge React](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/using-react) add authentication to API requests in the frontend and renders components outside of the App’s iFrame.
 - [Polaris React](https://polaris.shopify.com/) is a powerful design system and component library that helps developers build high quality, consistent experiences for Shopify merchants.
 - [Custom hooks](https://github.com/Shopify/shopify-frontend-template-react/tree/main/hooks) make authenticated requests to the Admin API.
 - [File-based routing](https://github.com/Shopify/shopify-frontend-template-react/blob/main/Routes.jsx) makes creating new pages easier.
@@ -97,7 +97,7 @@ cd ..
 
 ### Local Development
 
-[The Shopify CLI](https://shopify.dev/apps/tools/cli) connects to an app in your Partners dashboard.
+[The Shopify CLI](https://shopify.dev/docs/apps/tools/cli) connects to an app in your Partners dashboard.
 It provides environment variables, runs commands in parallel, and updates application URLs for easier development.
 
 You can develop locally using your preferred Node.js package manager.
@@ -170,9 +170,9 @@ rake build:all
 
 ## Hosting
 
-When you're ready to set up your app in production, you can follow [our deployment documentation](https://shopify.dev/apps/deployment/web) to host your app on a cloud provider like [Heroku](https://www.heroku.com/) or [Fly.io](https://fly.io/).
+When you're ready to set up your app in production, you can follow [our deployment documentation](https://shopify.dev/docs/apps/deployment/web) to host your app on a cloud provider like [Heroku](https://www.heroku.com/) or [Fly.io](https://fly.io/).
 
-When you reach the step for [setting up environment variables](https://shopify.dev/apps/deployment/web#set-env-vars), you also need to set the following variables:
+When you reach the step for [setting up environment variables](https://shopify.dev/docs/apps/deployment/web#set-env-vars), you also need to set the following variables:
 
 | Variable                   | Secret? | Required |     Value      | Description                                                 |
 | -------------------------- | :-----: | :------: | :------------: | ----------------------------------------------------------- |
@@ -254,7 +254,7 @@ pnpm dev --tunnel-url https://tunnel-url:3000
 
 ## Developer resources
 
-- [Introduction to Shopify apps](https://shopify.dev/apps/getting-started)
-- [App authentication](https://shopify.dev/apps/auth)
-- [Shopify CLI](https://shopify.dev/apps/tools/cli)
+- [Introduction to Shopify apps](https://shopify.dev/docs/apps/getting-started)
+- [App authentication](https://shopify.dev/docs/apps/auth)
+- [Shopify CLI](https://shopify.dev/docs/apps/tools/cli)
 - [Shopify API Library documentation](https://github.com/Shopify/shopify-api-ruby/tree/main/docs)

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -73,17 +73,17 @@ def add_gdpr_webhooks
     # The code that processes these webhooks is located in the `app/jobs` directory.
     #
     # 48 hours after a store owner uninstalls your app, Shopify invokes this SHOP_REDACT webhook.
-    # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#shop-redact
+    # https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#shop-redact
     { topic: "shop/redact", address: "api/webhooks/shop_redact" },
 
     # Store owners can request that data is deleted on behalf of a customer. When this happens,
     # Shopify invokes this CUSTOMERS_REDACT webhook to let your app know.
-    # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-redact
+    # https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-redact
     { topic: "customers/redact", address: "api/webhooks/customers_redact" },
 
     # Customers can request their data from a store owner. When this happens, Shopify invokes
     # this CUSTOMERS_DATA_REQUEST webhook to let your app know.
-    # https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
+    # https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
     { topic: "customers/data_request", address: "api/webhooks/customers_data_request" },
   ]
 


### PR DESCRIPTION
### WHY are these changes introduced?

Much of the api and app related content has been moved under /docs on the Shopify Dev site. This updates the links to point to the new locations.

### WHAT is this pull request doing?

See above ☝🏻 
