### PR TITLE
Add proxy instructions for non-API routes

### DIFF
--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get "/api", to: redirect(path: "/") # Needed because our engine root is /api but that breaks FE routing
 
   # If you are adding routes outside of the /api path, remember to also add a proxy rule for
-  # it in web/frontend/vite.config.js
+  # them in web/frontend/vite.config.js
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   # them in web/frontend/vite.config.js
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-  
+
   get "/api/products/count", to: "products#count"
   get "/api/products/create", to: "products#create"
 

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -6,8 +6,11 @@ Rails.application.routes.draw do
   mount ShopifyApp::Engine, at: "/api"
   get "/api", to: redirect(path: "/") # Needed because our engine root is /api but that breaks FE routing
 
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  # If you are adding routes outside of the /api path, remember to also add a proxy rule for
+  # it in web/frontend/vite.config.js
 
+  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  
   get "/api/products/count", to: "products#count"
   get "/api/products/create", to: "products#create"
 


### PR DESCRIPTION
In development mode, the frontend runs on a separate process, and proxies requests to the backend.

By default, that only happens for paths under `/api`, under the assumption that the app is a single-page application. When adding backend routes outside that path, it's important to remember that we need to add proxy exceptions too, or the FE will take over and render the react app in development.

This PR adds a comment to the routes file to help remind folks about the proxy rules.