### PR TITLE
Use new CLI env variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     env:
-      SHOPIFY_API_KEY: test-api-key
-      SHOPIFY_API_SECRET: test-secret-key
-      SCOPES: write_products
-      HOST: app-host-name.io
+      SHOPIFY_APP_API_KEY: test-api-key
+      SHOPIFY_APP_API_SECRET: test-secret-key
+      SHOPIFY_APP_SCOPES: write_products
+      SHOPIFY_APP_URL: https://app-host-name.io
       BUNDLE_GEMFILE: ${{ github.workspace }}/web/Gemfile
     strategy:
       fail-fast: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:3.1-alpine
 
-ARG SHOPIFY_API_KEY
-ENV SHOPIFY_API_KEY=$SHOPIFY_API_KEY
+ARG SHOPIFY_APP_API_KEY
+ENV SHOPIFY_APP_API_KEY=$SHOPIFY_APP_API_KEY
 
 RUN apk update && apk add nodejs npm git build-base sqlite-dev gcompat bash openssl-dev
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -137,8 +137,13 @@ Once you decide which database to use, you can configure your app to connect to 
 ### Build
 
 The frontend is a single page React app.
-It requires the `SHOPIFY_API_KEY` environment variable, which you can get by running `yarn run info --web-env`.
+It requires the `SHOPIFY_APP_API_KEY` environment variable, which you can get by running `yarn run info --web-env`.
 The CLI will set up the necessary environment variables for the build if you run its `build` command from your app's root:
+
+<!-- TODO Update CLI version here -->
+> **Note**: For apps created using Shopify CLI vX.Y.Z or earlier, some of the environment variables above use different names.
+>
+> For more information, refer to [Shopify CLI app structure](https://shopify.dev/docs/apps/tools/cli/structure#web-component-conventions).
 
 Using yarn in your app's root folder:
 
@@ -163,7 +168,7 @@ If you're manually building (for instance when deploying the `web` folder to pro
 
 ```shell
 cd web/frontend
-SHOPIFY_API_KEY=REPLACE_ME yarn build
+SHOPIFY_APP_API_KEY=REPLACE_ME yarn build
 cd ..
 rake build:all
 ```
@@ -193,8 +198,8 @@ We fixed this issue with v3.4.0 of the CLI, so after updating it, you can make t
 1. Change the definition `hmrConfig` object to be:
 
    ```js
-   const host = process.env.HOST
-     ? process.env.HOST.replace(/https?:\/\//, "")
+   const host = process.env.SHOPIFY_APP_URL
+     ? process.env.SHOPIFY_APP_URL.replace(/https?:\/\//, "")
      : "localhost";
 
    let hmrConfig;

--- a/web/config/boot.rb
+++ b/web/config/boot.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["SHOPIFY_APP_URL"] = "https://#{ENV["SHOPIFY_APP_URL"]}" unless ENV["SHOPIFY_APP_URL"]&.match(%r{https?://})
 ENV["HOST"] = "https://#{ENV["HOST"]}" unless ENV["HOST"]&.match(%r{https?://})
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/web/config/environments/development.rb
+++ b/web/config/environments/development.rb
@@ -10,6 +10,7 @@ Rails.application.configure do
   end << /[-\w.]+\.ngrok\.io/
 
   config.hosts << URI(ENV.fetch("HOST", "")).host if ENV.fetch("HOST", "").present?
+  config.hosts << URI(ENV.fetch("SHOPIFY_APP_URL", "")).host if ENV.fetch("SHOPIFY_APP_URL", "").present?
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -8,7 +8,7 @@ ShopifyApp.configure do |config|
   ]
   config.application_name = "My Shopify App"
   config.old_secret = ""
-  config.scope = ENV.fetch("SCOPES", "write_products") # See shopify.app.toml for scopes
+  config.scope = ENV.fetch("SHOPIFY_APP_SCOPES", ENV.fetch("SCOPES", "write_products")) # See shopify.app.toml for scopes
   # Consult this page for more scope options: https://shopify.dev/api/usage/access-scopes
   config.embedded_app = true
   config.after_authenticate_job = false
@@ -35,13 +35,13 @@ ShopifyApp.configure do |config|
   #   currency_code: "USD", # Only supports USD for now
   # )
 
-  config.api_key = ENV.fetch("SHOPIFY_API_KEY", "").presence
-  config.secret = ENV.fetch("SHOPIFY_API_SECRET", "").presence
+  config.api_key = ENV.fetch("SHOPIFY_APP_API_KEY", ENV.fetch("SHOPIFY_API_KEY", "")).presence
+  config.secret = ENV.fetch("SHOPIFY_APP_API_SECRET", ENV.fetch("SHOPIFY_API_SECRET", "")).presence
   config.myshopify_domain = ENV.fetch("SHOP_CUSTOM_DOMAIN", "").presence if ENV.fetch("SHOP_CUSTOM_DOMAIN", "").present?
 
   if defined? Rails::Server
-    raise("Missing SHOPIFY_API_KEY. See https://github.com/Shopify/shopify_app#requirements") unless config.api_key
-    raise("Missing SHOPIFY_API_SECRET. See https://github.com/Shopify/shopify_app#requirements") unless config.secret
+    raise("Missing SHOPIFY_APP_API_KEY. See https://github.com/Shopify/shopify_app#requirements") unless config.api_key
+    raise("Missing SHOPIFY_APP_API_SECRET. See https://github.com/Shopify/shopify_app#requirements") unless config.secret
   end
 end
 
@@ -51,7 +51,7 @@ Rails.application.config.after_initialize do
       api_key: ShopifyApp.configuration.api_key,
       api_secret_key: ShopifyApp.configuration.secret,
       api_version: ShopifyApp.configuration.api_version,
-      host_name: URI(ENV.fetch("HOST", "")).host || "",
+      host_name: URI(ENV.fetch("SHOPIFY_APP_URL", ENV.fetch("HOST", ""))).host || "",
       scope: ShopifyApp.configuration.scope,
       is_private: !ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", "").empty?,
       is_embedded: ShopifyApp.configuration.embedded_app,


### PR DESCRIPTION
### WHY are these changes introduced?

With https://github.com/Shopify/cli/pull/1789, the CLI will deprecate some env var names. While they will still be present so previous apps won't break, we should migrate new apps as soon as possible to the new format.

### WHAT is this pull request doing?

Using the new env vars, but falling back to the current ones.