### PR TITLE
chore: Add access control headers for embedded apps

### DIFF
--- a/web/config/application.rb
+++ b/web/config/application.rb
@@ -16,11 +16,11 @@ module ShopifyAppTemplateRuby
     config.assets.prefix = "/api/assets"
 
     if ShopifyAPI::Context.embedded?
-      config.action_dispatch.default_headers = {
+      config.action_dispatch.default_headers = config.action_dispatch.default_headers.merge({
         "Access-Control-Allow-Origin" => "*",
         "Access-Control-Allow-Headers" => "Authorization",
         "Access-Control-Expose-Headers" => "X-Shopify-API-Request-Failure-Reauthorize-Url",
-      }
+      })
     end
 
     # Configuration for the application, engines, and railties goes here.

--- a/web/config/application.rb
+++ b/web/config/application.rb
@@ -15,6 +15,14 @@ module ShopifyAppTemplateRuby
 
     config.assets.prefix = "/api/assets"
 
+    if ShopifyAPI::Context.embedded?
+      config.action_dispatch.default_headers = {
+        "Access-Control-Allow-Origin" => "*",
+        "Access-Control-Allow-Headers" => "Authorization",
+        "Access-Control-Expose-Headers" => "X-Shopify-API-Request-Failure-Reauthorize-Url",
+      }
+    end
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
### WHY are these changes introduced?

Embedded apps need to set certain headers to ensure they can run in an iframe and receive requests from extensions.
 
### WHAT is this pull request doing?

This PR checks if the app is embedded and if so, sets the following headers for all responses:

- `Access-Control-Allow-Origin`
- `Access-Control-Allow-Headers`
- `Access-Control-Expose-Headers`

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [x] I have made changes to the `README.md` file and other related documentation, if applicable (N/A)
