### PR TITLE
[FIX] Tweaking Docker setup to enable running shell commands when deployed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,5 @@ COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 
 ENTRYPOINT ["entrypoint.sh"]
+
+CMD rails server -b 0.0.0.0 -e production

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,11 @@
 set -e
 
 # Remove a potentially pre-existing server.pid for Rails.
-rm -f /app/tmp/pids/server.pid
+if [ -f /app/tmp/pids/server.pid ]; then
+  rm -f /app/tmp/pids/server.pid
+fi
 
 bin/rails db:create
 bin/rails db:migrate
 
-rails server -b 0.0.0.0 -e production
+exec "$@"


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes #100

The default Docker implementation for this template hardcodes the `rails server` startup within the `entrypoint.sh`. This disables the ability to run other commands when the container is running. For example, when deployed to Heroku, you cannot open a shell to your container.

### WHAT is this pull request doing?

It moves the `rails server` startup command outside of `entrypoint.sh` and into the `Dockerfile`, supporting the existing behavior. However, it also allows you to override the CMD being run so you can execute shell commands as well.

It also adds a sanity check before deleting the existing `server.pid` in case it doesn't actually exist.

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [-] I have added/updated tests for this change
- [-] I have made changes to the `README.md` file and other related documentation, if applicable
