### PR TITLE
Fix build.rake to use relative paths instead of absolute paths

### DIFF
--- a/web/lib/tasks/build.rake
+++ b/web/lib/tasks/build.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pathname'
 
 namespace :build do
   desc "Run all build tasks"
@@ -6,10 +7,20 @@ namespace :build do
 
   desc "Build symlinks for FE assets"
   task build_frontend_links: :environment do
-    index_path = File.join(__dir__, "../../public/dist/index.html")
-    assets_path = File.join(__dir__, "../../public/assets")
+    # Define paths using Pathname
+    index_path = Pathname.new(File.join(__dir__, "../../public/dist/index.html"))
+    assets_path = Pathname.new(File.join(__dir__, "../../public/assets"))
 
-    File.symlink(File.join(__dir__, "../../frontend/dist/index.html"), index_path) unless File.symlink?(index_path)
-    File.symlink(File.join(__dir__, "../../frontend/dist/assets"), assets_path) unless File.symlink?(assets_path)
+    # Targets for the symlinks
+    index_target = Pathname.new(File.join(__dir__, "../../frontend/dist/index.html"))
+    assets_target = Pathname.new(File.join(__dir__, "../../frontend/dist/assets"))
+
+    # Compute relative paths
+    relative_index_target = index_target.relative_path_from(index_path.dirname)
+    relative_assets_target = assets_target.relative_path_from(assets_path.dirname)
+
+    # Create symlinks if they don't already exist
+    index_path.make_symlink(relative_index_target) unless index_path.symlink?
+    assets_path.make_symlink(relative_assets_target) unless assets_path.symlink?
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #108 

When deploying to a production environment (on fly.io with Linux), the application encounters a `Errno::ENOENT` error related to a symlink pointing to `index.html` in the `public/dist` directory. This symlink is generated correctly in a local Mac environment but fails in production due to its absolute path.

### WHAT is this pull request doing?

This pull request modifies the Rake task responsible for generating the symlinks to use relative paths instead of absolute paths. By using relative paths, the symlinks become more portable and are less likely to break when deployed in different environments. The path will not the the one of the laptop where the build was made

(If applicable, attach before/after screenshots to visually showcase the change)

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
