### PR TITLE
Update ProudctCreate mutation

### DIFF
--- a/web/app/services/product_creator.rb
+++ b/web/app/services/product_creator.rb
@@ -28,8 +28,7 @@ class ProductCreator < ApplicationService
         query: CREATE_PRODUCTS_MUTATION,
         variables: {
           input: {
-            title: random_title,
-            variants: [{ price: random_price }],
+            title: random_title
           },
         },
       )


### PR DESCRIPTION


### WHY are these changes introduced?

* As of 2024-04 API version, you can no longer set the variant price in the productCreate mutation

### WHAT is this pull request doing?

* This removes setting the variant price

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
