### PR TITLE
Update shopify_app gem dependency

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -75,4 +75,4 @@ group :test do
   gem "webdrivers"
 end
 
-gem "shopify_app", "~> 21.9"
+gem "shopify_app", "~> 22.0"


### PR DESCRIPTION
This PR updates the dependency on `shopify_app` - none of the [breaking changes from v22](https://github.com/Shopify/shopify_app/blob/main/docs/Upgrading.md#upgrading-to-v2200) affect the template.