### PR TITLE
Update template to use token exchange

### DIFF
--- a/web/app/controllers/products_controller.rb
+++ b/web/app/controllers/products_controller.rb
@@ -10,18 +10,10 @@ class ProductsController < AuthenticatedController
 
   # POST /api/products
   def create
-    ProductCreator.call(count: 5, session: current_shopify_session)
-
-    success = true
-    error = nil
-    status_code = 200
+    ProductCreator.call(count: 5, session: current_shopify_session, id_token: shopify_id_token)
+    render(json: { success: true, error: nil })
   rescue => e
-    success = false
-    error = e.message
-    status_code = e.is_a?(ShopifyAPI::Errors::HttpResponseError) ? e.code : 500
-
-    logger.info("Failed to create products: #{error}")
-  ensure
-    render(json: { success: success, error: error }, status: status_code)
+    logger.error("Failed to create products: #{e.message}")
+    render(json: { success: false, error: e.message }, status: e.try(:code) || :internal_server_error)
   end
 end

--- a/web/app/services/application_service.rb
+++ b/web/app/services/application_service.rb
@@ -6,4 +6,6 @@ class ApplicationService
       new(*args, **kwargs, &block).call
     end
   end
+
+  def initialize(*args, **kwargs, &block); end
 end

--- a/web/app/services/product_creator.rb
+++ b/web/app/services/product_creator.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class ProductCreator < ApplicationService
+  include ShopifyApp::AdminAPI::WithTokenRefetch
+
   attr_reader :count
 
   CREATE_PRODUCTS_MUTATION = <<~QUERY
-    mutation populateProduct($input: ProductInput!) {
-      productCreate(input: $input) {
+    mutation populateProduct($title: String!) {
+      productCreate(input: {title: $title}) {
         product {
           title
           id
@@ -14,41 +16,29 @@ class ProductCreator < ApplicationService
     }
   QUERY
 
-  def initialize(count:, session:)
-    super()
+  def initialize(count:, session:, id_token:)
+    super
     @count = count
     @session = session
+    @id_token = id_token
   end
 
   def call
-    client = ShopifyAPI::Clients::Graphql::Admin.new(session: @session)
+    count.times do
+      response = with_token_refetch(@session, @id_token) do
+        client = ShopifyAPI::Clients::Graphql::Admin.new(session: @session)
+        client.query(query: CREATE_PRODUCTS_MUTATION, variables: { title: random_title })
+      end
 
-    (1..count).each do |_i|
-      response = client.query(
-        query: CREATE_PRODUCTS_MUTATION,
-        variables: {
-          input: {
-            title: random_title,
-          },
-        },
-      )
-
-      created_product = response.body["data"]["productCreate"]["product"]
-      ShopifyAPI::Logger.info("Created Product | Title: '#{created_product["title"]}' | Id: '#{created_product["id"]}'")
+      created_product = response.body.dig("data", "productCreate", "product")
+      Rails.logger.info("Created Product | Title: '#{created_product["title"]}' | Id: '#{created_product["id"]}'")
     end
   end
 
   private
 
   def random_title
-    adjective = ADJECTIVES[rand(ADJECTIVES.size)]
-    noun = NOUNS[rand(NOUNS.size)]
-
-    "#{adjective} #{noun}"
-  end
-
-  def random_price
-    (100.0 + rand(1000)) / 100
+    "#{ADJECTIVES.sample} #{NOUNS.sample}"
   end
 
   ADJECTIVES = [

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -16,6 +16,8 @@ ShopifyApp.configure do |config|
   config.shop_session_repository = "Shop"
 
   config.reauth_on_access_scope_changes = true
+  config.wip_new_embedded_auth_strategy = true
+  config.check_session_expiry_date = true
 
   config.root_url = "/api"
   config.login_url = "/api/auth"


### PR DESCRIPTION
### WHY are these changes introduced?

We want to use the new embedded app auth strategy by default.

### WHAT is this pull request doing?

- Enable `wip_new_embedded_auth_strategy` and `check_session_expiry_date` by default
- Use `with_token_refetch` in `ProductCreator` to perform token exchange when access token is invalid

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
