### PR TITLE
Revert rubocop unwanted changes

### DIFF
--- a/web/bin/bundle
+++ b/web/bin/bundle
@@ -24,7 +24,6 @@ m = Module.new do
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
     return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
-
     bundler_version = nil
     update_index = nil
     ARGV.each_with_index do |a, i|
@@ -32,7 +31,6 @@ m = Module.new do
         bundler_version = a
       end
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-
       bundler_version = $1
       update_index = i
     end
@@ -57,17 +55,15 @@ m = Module.new do
 
   def lockfile_version
     return unless File.file?(lockfile)
-
     lockfile_contents = File.read(lockfile)
     return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
-
     Regexp.last_match(1)
   end
 
   def bundler_requirement
     @bundler_requirement ||=
       env_var_version || cli_arg_version ||
-      bundler_requirement_for(lockfile_version)
+        bundler_requirement_for(lockfile_version)
   end
 
   def bundler_requirement_for(version)
@@ -95,12 +91,10 @@ m = Module.new do
       gem "bundler", bundler_requirement
     end
     return if gem_error.nil?
-
     require_error = activation_error_handling do
       require "bundler/version"
     end
     return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
-
     warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end

--- a/web/bin/importmap
+++ b/web/bin/importmap
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
 require_relative "../config/application"
 require "importmap/commands"

--- a/web/bin/rails
+++ b/web/bin/rails
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"

--- a/web/bin/rake
+++ b/web/bin/rake
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require_relative "../config/boot"
 require "rake"
 Rake.application.run

--- a/web/bin/setup
+++ b/web/bin/setup
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
-
 require "fileutils"
 
 # path to your application root.

--- a/web/db/migrate/20220609125627_create_shops.rb
+++ b/web/db/migrate/20220609125627_create_shops.rb
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
-
 class CreateShops < ActiveRecord::Migration[7.0]
   def self.up
-    create_table :shops do |t|
+    create_table :shops  do |t|
       t.string :shopify_domain, null: false
       t.string :shopify_token, null: false
       t.timestamps

--- a/web/db/migrate/20220609125631_add_shop_access_scopes_column.rb
+++ b/web/db/migrate/20220609125631_add_shop_access_scopes_column.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class AddShopAccessScopesColumn < ActiveRecord::Migration[7.0]
   def change
     add_column :shops, :access_scopes, :string

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_220_922_200_143) do
+ActiveRecord::Schema[7.1].define(version: 2022_09_22_200143) do
   create_table "shops", force: :cascade do |t|
     t.string "shopify_domain", null: false
     t.string "shopify_token", null: false
@@ -31,4 +29,5 @@ ActiveRecord::Schema[7.1].define(version: 20_220_922_200_143) do
     t.string "access_scopes"
     t.index ["shopify_user_id"], name: "index_users_on_shopify_user_id", unique: true
   end
+
 end

--- a/web/db/seeds.rb
+++ b/web/db/seeds.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #


### PR DESCRIPTION
### WHY are these changes introduced?

With #133, I used the global rubocop configuration first and I changed some files that were excluded by the project-specific Rubocop rules. I re-run the right configuration later, but since those files are excluded, the changes were not reverted.

Those changes are unnecessary, and this PR is reverting the files to the previous version. 


## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
