### PR TITLE
[Fix] Revert "Add declarative webhooks and remove imperative"

### DIFF
--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 ShopifyApp.configure do |config|
+  config.webhooks = [
+    # After a store owner uninstalls your app, Shopify invokes the APP_UNINSTALLED webhook
+    # to let your app know.
+    { topic: "app/uninstalled", address: "api/webhooks/app_uninstalled" },
+  ]
   config.application_name = "My Shopify App"
   config.old_secret = ""
   config.scope = ENV.fetch("SCOPES", "write_products") # See shopify.app.toml for scopes
@@ -56,5 +61,36 @@ Rails.application.config.after_initialize do
       private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
       user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
     )
+
+    add_privacy_webhooks
+    ShopifyApp::WebhooksManager.add_registrations
+  end
+end
+
+def add_privacy_webhooks
+  privacy_webhooks = [
+    # NOTE: To register the URLs for the three privacy topics that follow, please set the appropriate
+    # webhook endpoint in the 'Privacy webhooks' section of 'App setup' in the Partners Dashboard.
+    # The code that processes these webhooks is located in the `app/jobs` directory.
+    #
+    # 48 hours after a store owner uninstalls your app, Shopify invokes this SHOP_REDACT webhook.
+    # https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#shop-redact
+    { topic: "shop/redact", address: "api/webhooks/shop_redact" },
+
+    # Store owners can request that data is deleted on behalf of a customer. When this happens,
+    # Shopify invokes this CUSTOMERS_REDACT webhook to let your app know.
+    # https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-redact
+    { topic: "customers/redact", address: "api/webhooks/customers_redact" },
+
+    # Customers can request their data from a store owner. When this happens, Shopify invokes
+    # this CUSTOMERS_DATA_REQUEST webhook to let your app know.
+    # https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks#customers-data_request
+    { topic: "customers/data_request", address: "api/webhooks/customers_data_request" },
+  ]
+
+  ShopifyApp.configuration.webhooks = if ShopifyApp.configuration.has_webhooks?
+    ShopifyApp.configuration.webhooks.concat(privacy_webhooks)
+  else
+    privacy_webhooks
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/shopify-api-ruby/issues/1328

This reverts commit 82b9d7a174447098911f0a198b57fc922531578f.

The template is not set up to handle declarative webhooks config yet. It's still relying on the convention of matching webhook topic with a job class after registering with a centralized manager.

https://github.com/Shopify/shopify_app/blob/b921685a0dbf1948905cd3057d35d2f484cdbce8/lib/shopify_app/managers/webhooks_manager.rb#L53

### WHAT is this pull request doing?

Adds back webhook registrations for compliance topics and app/uninstalled

### Test this PR

```
shopify app init --template=https://github.com/Shopify/shopify-app-template-ruby#sle-c/revert-declarative-webhook-config
```

Run `shopify app dev` and preview the app in your test shop

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [x] I have made changes to the `README.md` file and other related documentation, if applicable
