### PR TITLE
[Chore] Fix test requires

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -73,6 +73,8 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem "webmock"
+  gem "mocha"
 end
 
 gem "shopify_app", "~> 22.2"

--- a/web/test/test_helper.rb
+++ b/web/test/test_helper.rb
@@ -6,6 +6,7 @@ require "rails/test_help"
 
 require "minitest/autorun"
 require "webmock/minitest"
+require "mocha/minitest"
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, we can't import test helpers from `shopify_app` because they require some dependencies we're missing.

### WHAT is this pull request doing?

Adding / loading the dependencies.