### PR TITLE
Update access scopes in DB from `app_scopes_update` webhook subscription

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,11 @@
 scopes = "write_products"
 
 [webhooks]
-api_version = "2024-07"
+api_version = "2024-10"
+
+  [[webhooks.subscriptions]]
+  topics = [ "app/scopes_update" ]
+  uri = "/api/webhooks/app_scopes_update"
 
   [[webhooks.subscriptions]]
   uri = "/api/webhooks/app_uninstalled"

--- a/web/app/controllers/webhooks/app_scopes_update_controller.rb
+++ b/web/app/controllers/webhooks/app_scopes_update_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Webhooks
+  class AppScopesUpdateController < ApplicationController
+    include ShopifyApp::WebhookVerification
+
+    def receive
+      webhook_request = ShopifyAPI::Webhooks::Request.new(raw_body: request.raw_post, headers: request.headers.to_h)
+      AppScopesUpdateJob.perform_later(shop_domain: webhook_request.shop, webhook: webhook_request.parsed_body)
+      head(:no_content)
+    end
+  end
+end

--- a/web/app/jobs/app_scopes_update_job.rb
+++ b/web/app/jobs/app_scopes_update_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AppScopesUpdateJob < ActiveJob::Base
+  def perform(shop_domain:, webhook:)
+    logger.info("#{self.class} started for shop '#{shop_domain}'")
+    shop = Shop.find_by(shopify_domain: shop_domain)
+
+    if shop.nil?
+      logger.error("#{self.class} failed: cannot find shop with domain '#{shop_domain}'")
+      return
+    end
+
+    shop.access_scopes = webhook["current"].join(",")
+    shop.save!
+  end
+end

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     end
     namespace :webhooks do
       post "/app_uninstalled", to: "app_uninstalled#receive"
+      post "/app_scopes_update", to: "app_scopes_update#receive"
       post "/customers_data_request", to: "customers_data_request#receive"
       post "/customers_redact", to: "customers_redact#receive"
       post "/shop_redact", to: "shop_redact#receive"


### PR DESCRIPTION
### WHY are these changes introduced?
Closes: https://github.com/Shopify/develop-app-runtime-primitives/issues/387
Relates to: https://github.com/Shopify/shopify-app-template-remix/pull/875

### WHAT is this pull request doing?
- Add new webhook subscription for `app_scopes_update`
- Add controller & job to handle `app_scopes_update` webhook to update the DB's `access_scopes` column

### Tophatting:
1. Init new app from template
```
shopify app init --template=https://github.com/Shopify/shopify-app-template-ruby#zoey/subscribe-scope-update-webhook
```
2. Create and install new app on a store
3. See a record in `shop` DB for the installed shop
4. Update `shopify.app.toml` to include different `scopes`
5. Reload the app and approve newly requested scopes
6. See the webhook request and the DB column is updated for the app.

https://screenshot.click/30-52-obkwf-t5j34.mp4

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [x] I have added/updated tests for this change
- [x] I have made changes to the `README.md` file and other related documentation, if applicable
