### PR TITLE
Fix: Use GraphQL queries in the Ruby app template and remove Rest

### DIFF
--- a/web/app/controllers/products_controller.rb
+++ b/web/app/controllers/products_controller.rb
@@ -3,9 +3,12 @@
 class ProductsController < AuthenticatedController
   # GET /api/products/count
   def count
-    product_count = ShopifyAPI::Product.count.body
+    product_count = ProductCounter.call(session: current_shopify_session, id_token: shopify_id_token)
     ShopifyAPI::Logger.info("Retrieved product count: #{product_count["count"]}")
     render(json: product_count)
+  rescue StandardError => e
+    logger.error("Failed to retrieve product count: #{e.message}")
+    render(json: { success: false, error: e.message }, status: e.try(:code) || :internal_server_error)
   end
 
   # POST /api/products

--- a/web/app/services/product_counter.rb
+++ b/web/app/services/product_counter.rb
@@ -28,4 +28,3 @@ class ProductCounter < ApplicationService
     response.body.dig("data", "productsCount")
   end
 end
-

--- a/web/app/services/product_counter.rb
+++ b/web/app/services/product_counter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ProductCounter < ApplicationService
+  include ShopifyApp::AdminAPI::WithTokenRefetch
+
+  GET_PRODUCT_COUNT_QUERY = <<~QUERY
+    query countProducts {
+      productsCount {
+        count
+      }
+    }
+  QUERY
+
+  def initialize(session:, id_token:)
+    super
+    @session = session
+    @id_token = id_token
+  end
+
+  def call
+    response = with_token_refetch(@session, @id_token) do
+      client = ShopifyAPI::Clients::Graphql::Admin.new(session: @session)
+      client.query(query: GET_PRODUCT_COUNT_QUERY)
+    end
+
+    raise StandardError, response.body["errors"].to_s if response.body["errors"]
+
+    response.body.dig("data", "productsCount")
+  end
+end
+


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

Test with this command
```
shopify app init --template=https://github.com/Shopify/shopify-app-template-ruby#andy-liuu/Use-GraphQL-queries-in-the-Ruby-app-template-and-remove-Rest       
```

### WHY are these changes introduced? 

Fixes https://github.com/Shopify/first-party-library-planning/issues/691

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Converting the rest api call to a graphql call
- using the same style as the other gql call

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
not applicable

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
not applicable
