### PR TITLE
Remove shopify app package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "info": "shopify app info"
   },
   "dependencies": {
-    "@shopify/app": "^3.0.0",
-    "@shopify/cli": "^3.0.0"
+    "@shopify/cli": "^3.59.0"
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

I see this warning
```
warning @shopify/app@3.58.2: This package is deprecated. As of Shopify CLI version 3.59.0, it is bundled with @shopify/cli. Please use that package instead.
```

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Removes `@shopify/app` package
- Specify `@shopify/cli` version to use bundled version

## Checklist

**Note**: once this PR is merged, it becomes a new release for this template.

- [ ] I have added/updated tests for this change
- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
