### PR TITLE
Make expiring offline tokens the default configuration

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -77,4 +77,4 @@ group :test do
   gem "mocha"
 end
 
-gem "shopify_app", "~> 22.2"
+gem "shopify_app", "~> 23.0"

--- a/web/app/models/shop.rb
+++ b/web/app/models/shop.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Shop < ActiveRecord::Base
-  include ShopifyApp::ShopSessionStorageWithScopes
+  include ShopifyApp::ShopSessionStorage
 
   def api_version
     ShopifyApp.configuration.api_version

--- a/web/app/models/user.rb
+++ b/web/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ActiveRecord::Base
-  include ShopifyApp::UserSessionStorageWithScopes
+  include ShopifyApp::UserSessionStorage
 
   def api_version
     ShopifyApp.configuration.api_version

--- a/web/config/initializers/shopify_app.rb
+++ b/web/config/initializers/shopify_app.rb
@@ -6,7 +6,7 @@ ShopifyApp.configure do |config|
   # Consult this page for more scope options: https://shopify.dev/api/usage/access-scopes
   config.embedded_app = true
   config.after_authenticate_job = false
-  config.api_version = ShopifyAPI::AdminVersions::LATEST_SUPPORTED_ADMIN_VERSION
+  config.api_version = "2025-10"
 
   # Offline Access Tokens Configuration
   # https://shopify.dev/docs/apps/build/authentication-authorization/access-token-types/offline-access-tokens
@@ -19,6 +19,9 @@ ShopifyApp.configure do |config|
 
   config.reauth_on_access_scope_changes = true
   config.new_embedded_auth_strategy = true
+
+  # Automatically trigger re-authentication when the session has expired.
+  config.check_session_expiry_date = true
 
   config.root_url = "/api"
   config.login_url = "/api/auth"
@@ -66,6 +69,7 @@ Rails.application.config.after_initialize do
       private_shop: ENV.fetch("SHOPIFY_APP_PRIVATE_SHOP", nil),
       user_agent_prefix: "ShopifyApp/#{ShopifyApp::VERSION}",
       old_api_secret_key: ShopifyApp.configuration.old_secret,
+      expiring_offline_access_tokens: true,
     )
   end
 end

--- a/web/db/migrate/20251119190208_add_shop_access_token_expiry_columns.rb
+++ b/web/db/migrate/20251119190208_add_shop_access_token_expiry_columns.rb
@@ -1,0 +1,7 @@
+class AddShopAccessTokenExpiryColumns < ActiveRecord::Migration[7.1]
+  def change
+    add_column :shops, :expires_at, :datetime
+    add_column :shops, :refresh_token, :string
+    add_column :shops, :refresh_token_expires_at, :datetime
+  end
+end

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -10,13 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_15_093250) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_19_190208) do
   create_table "shops", force: :cascade do |t|
     t.string "shopify_domain", null: false
     t.string "shopify_token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "access_scopes"
+    t.datetime "expires_at"
+    t.string "refresh_token"
+    t.datetime "refresh_token_expires_at"
     t.index ["shopify_domain"], name: "index_shops_on_shopify_domain", unique: true
   end
 


### PR DESCRIPTION
- https://github.com/shop/issues-app-access/issues/791


Depends on:
- New version of `shopify-api-ruby` gem after this change:
  - https://github.com/Shopify/shopify-api-ruby/pull/1423
- New version of `shopify_app` gem after this change:
  - https://github.com/Shopify/shopify_app/pull/2027  

### WHAT is this pull request doing?
- Make expiring offline tokens the default configuration
- Add db schema migration file with necessary columns and make that the default

