### PR TITLE
Use regular CLAUDE.md import for AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
Related to https://github.com/shop/issues-develop/issues/22870

Replaces the symlink added in #201 with Claude Code's `@AGENTS.md` file import directive. This keeps `CLAUDE.md` as a regular file so Windows checkouts without symlink support still load `AGENTS.md`.

Prior PR: #201