### PR TITLE
Make AI Toolkit skill discovery non-interactive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,4 @@
 
 This app is scaffolded from a Shopify app template. See the README for framework-specific details.
 
-Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work. If missing, install it in the agent host per that page (or `npx skills add Shopify/shopify-ai-toolkit` for skill-compatible hosts) — do not add tooling to this repo.
+Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work. If missing, install it in the agent host per that page (or `npx skills add Shopify/shopify-ai-toolkit --list` for skill-compatible hosts) — do not add tooling to this repo.


### PR DESCRIPTION
Related to [shop/issues-develop#22870](https://github.com/shop/issues-develop/issues/22870)

Update the recommended skill command to use npx skills add Shopify/shopify-ai-toolkit --list, which works non-interactively.